### PR TITLE
Improve Content Calendar Usability, Client Account Management & Mobile Drag UX

### DIFF
--- a/actions/projectActions.ts
+++ b/actions/projectActions.ts
@@ -18,6 +18,7 @@ import {
   sendProjectFeedbackEmail,
   sendProjectSubmissionEmail,
 } from "./emailActions";
+import { Prisma } from "@prisma/client";
 
 type ProjectDataType = {
   title: string;
@@ -314,7 +315,7 @@ export async function rejectProject(projectId: string, feedback: string) {
 
     const updatedProject = await prisma.project.update({
       where: { id: projectId },
-      data: { feedback, status: "REJECTED", completedFile: {} },
+      data: { feedback, status: "REJECTED", completedFile: Prisma.JsonNull },
       include: {
         createdBy: {
           include: {

--- a/app/client-management/[id]/dashboard/page.tsx
+++ b/app/client-management/[id]/dashboard/page.tsx
@@ -1,0 +1,24 @@
+import ClientDashboardContent from "@/components/client-dashboard/ClientDashboardContent";
+import { getClientProjects } from "@/services/projectServices";
+import { getUserById } from "@/services/userServices";
+import React from "react";
+
+export default async function page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id: clientId } = await params;
+  const { data: user } = await getUserById(clientId);
+  const { data: projects } = await getClientProjects(user?.id || "");
+
+  return (
+    <main className="w-full flex-1">
+      <ClientDashboardContent
+        clientVideoTypes={user?.videoTypes || []}
+        clientVideoScripts={user?.videoScripts || []}
+        projects={projects}
+      />
+    </main>
+  );
+}

--- a/app/client-management/[id]/newsletter-content/page.tsx
+++ b/app/client-management/[id]/newsletter-content/page.tsx
@@ -1,0 +1,22 @@
+import ClientNewsletterPageContent from "@/components/newsletter-content/ClientNewsletterPageContent";
+import { getClientApprovedProjects } from "@/services/projectServices";
+import { getUserById } from "@/services/userServices";
+import React from "react";
+
+export default async function page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id: clientId } = await params;
+  const { data: user } = await getUserById(clientId);
+  const { data: projects } = await getClientApprovedProjects(user?.id || "");
+
+  return (
+    <ClientNewsletterPageContent
+      projects={projects}
+      creditsUsedThisMonth={user?.creditsUsedThisMonth || 0}
+      totalCredits={user?.monthlyCredits || 2}
+    />
+  );
+}

--- a/app/client-management/page.tsx
+++ b/app/client-management/page.tsx
@@ -15,11 +15,11 @@ export default async function UserManagementPage() {
         </h1>
       </div>
       <div className="mx-auto flex w-[90%] max-w-7xl flex-col gap-6 py-4">
-        <div className="grid min-[480px]:grid-cols-2 sm:grid-cols-[repeat(auto-fill,_minmax(240px,_1fr))]">
+        <div className="grid gap-4 min-[480px]:grid-cols-2 sm:grid-cols-[repeat(auto-fill,_minmax(240px,_1fr))]">
           {clients.map((client) => (
             <div
               key={client.id}
-              className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 p-4 shadow-xl duration-200 sm:p-6"
+              className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 p-4 shadow-md duration-200 sm:p-6"
             >
               <Avatar user={client} className="h-20 w-20" />
               <div className="flex flex-1 flex-col items-center text-center">

--- a/app/client-management/page.tsx
+++ b/app/client-management/page.tsx
@@ -1,0 +1,49 @@
+import ToggleSidebarButton from "@/components/sidebar/ToggleSidebarButton";
+import Avatar from "@/components/ui/Avatar";
+import { getClients } from "@/services/userServices";
+import Link from "next/link";
+
+export default async function UserManagementPage() {
+  const { data: clients } = await getClients();
+
+  return (
+    <main className="flex-1">
+      <div className="flex items-center justify-between border-b border-gray-200 px-[5%] py-4">
+        <h1 className="flex text-xl font-bold md:text-2xl xl:text-[28px]">
+          <ToggleSidebarButton />
+          Client Management
+        </h1>
+      </div>
+      <div className="mx-auto flex w-[90%] max-w-7xl flex-col gap-6 py-4">
+        <div className="grid min-[480px]:grid-cols-2 sm:grid-cols-[repeat(auto-fill,_minmax(240px,_1fr))]">
+          {clients.map((client) => (
+            <div
+              key={client.id}
+              className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 p-4 shadow-xl duration-200 sm:p-6"
+            >
+              <Avatar user={client} className="h-20 w-20" />
+              <div className="flex flex-1 flex-col items-center text-center">
+                <h2 className="text-lg font-semibold">{client.fullName}</h2>
+                <p className="text-sm text-gray-500">{client.companyName}</p>
+              </div>
+              <div className="mt-2 flex w-full flex-col gap-2">
+                <Link
+                  href={`/client-management/${client.id}/dashboard`}
+                  className="hover:bg-accent rounded-md border border-gray-200 px-4 py-2 text-center text-sm font-medium duration-150 hover:text-white"
+                >
+                  Client Dashboard
+                </Link>
+                <Link
+                  href={`/client-management/${client.id}/newsletter-content`}
+                  className="hover:bg-accent rounded-md border border-gray-200 px-4 py-2 text-center text-sm font-medium duration-150 hover:text-white"
+                >
+                  Newsletter Content
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,8 @@ import {
   getClientProjects,
   getFreelancerClientProjects,
 } from "@/services/projectServices";
+import { getFreelancerClients } from "@/services/userServices";
+import { UserType } from "@/types/user";
 
 export default async function Home() {
   const { data: user } = await getSession();
@@ -14,6 +16,13 @@ export default async function Home() {
       : await getFreelancerClientProjects(
           user?.assignedClients.map((cl) => cl.id) || [],
         );
+
+  let clients: UserType[] = [];
+
+  if (user?.role === "FREELANCER") {
+    const { data } = await getFreelancerClients(user.id);
+    clients = data;
+  }
 
   return (
     <main className="w-full flex-1">
@@ -25,7 +34,7 @@ export default async function Home() {
           permission="FULL"
         />
       ) : (
-        <FreelancerDashboardContent projects={projects} />
+        <FreelancerDashboardContent projects={projects} clients={clients} />
       )}
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ export default async function Home() {
           clientVideoTypes={user?.videoTypes || []}
           clientVideoScripts={user?.videoScripts || []}
           projects={projects}
+          permission="FULL"
         />
       ) : (
         <FreelancerDashboardContent projects={projects} />

--- a/components/auth/LogoutModal.tsx
+++ b/components/auth/LogoutModal.tsx
@@ -6,12 +6,17 @@ import { logoutUser } from "@/actions/authActions";
 
 export default function LogoutModal({
   open,
-  closeModal,
+  closeModal: closeLogoutModal,
 }: {
   open: boolean;
   closeModal: () => void;
 }) {
   const [loading, setLoading] = useState(false);
+
+  function closeModal() {
+    if (loading) return;
+    closeLogoutModal();
+  }
 
   async function handleLogout() {
     setLoading(true);

--- a/components/client-dashboard/ClientDashboardContent.tsx
+++ b/components/client-dashboard/ClientDashboardContent.tsx
@@ -8,15 +8,19 @@ import { ProjectType } from "@/types/project";
 import ProjectDetailsModal from "../project/ProjectDetailsModal";
 import ProjectsAwaitingApprovalSection from "./ProjectsAwaitingAprovalSection";
 import { VideoScriptType } from "@/types/videoScript";
+import Link from "next/link";
+import { ArrowLeftIcon } from "lucide-react";
 
 export default function ClientDashboardContent({
   clientVideoTypes,
   clientVideoScripts,
   projects: fetchedProjects,
+  permission = "BASIC",
 }: {
   clientVideoTypes: string[];
   clientVideoScripts: VideoScriptType[];
   projects: ProjectType[];
+  permission?: "BASIC" | "FULL";
 }) {
   const [projects, setProjects] = useState(fetchedProjects);
   const [projectDetailsModalOpen, setProjectDetailsModalOpen] = useState(false);
@@ -54,11 +58,20 @@ export default function ClientDashboardContent({
           <ToggleSidebarButton />
           Client Dashboard
         </h1>
-        <UploadVideoButton
-          updateProjects={updateProjects}
-          videoTypes={clientVideoTypes}
-          videoScripts={clientVideoScripts}
-        />
+        {permission === "FULL" ? (
+          <UploadVideoButton
+            updateProjects={updateProjects}
+            videoTypes={clientVideoTypes}
+            videoScripts={clientVideoScripts}
+          />
+        ) : (
+          <Link
+            href={"/client-management"}
+            className="flex items-center gap-2 hover:underline"
+          >
+            <ArrowLeftIcon className="h-4 w-4" /> Back
+          </Link>
+        )}
       </div>
 
       <div className="mx-auto flex w-[90%] max-w-7xl flex-col gap-6 py-4">

--- a/components/freelancer-dashboard/FreelancerDashboardContent.tsx
+++ b/components/freelancer-dashboard/FreelancerDashboardContent.tsx
@@ -1,21 +1,39 @@
 "use client";
 
 import { ProjectType } from "@/types/project";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import ToggleSidebarButton from "../sidebar/ToggleSidebarButton";
 
 import ProjectDetailsModal from "../project/ProjectDetailsModal";
 import PendingProjectsSection from "./PendingProjectsSection";
 import ContentCalendar from "../project/ContentCalendar";
+import Select from "../ui/Select";
+import { UserType } from "@/types/user";
 
 export default function FreelancerDashboardContent({
   projects: fetchedProjects,
+  clients,
 }: {
   projects: ProjectType[];
+  clients: UserType[];
 }) {
   const [projects, setProjects] = useState(fetchedProjects);
   const [projectDetailsModalOpen, setProjectDetailsModalOpen] = useState(false);
   const [projectToView, setProjectToView] = useState<ProjectType | null>(null);
+  const [selectedClientId, setSelectedClientId] = useState("all");
+
+  const selectedClient = useMemo(
+    () => clients.find((cl) => cl.id === selectedClientId),
+    [clients, selectedClientId],
+  );
+
+  const filteredProjects = useMemo(
+    () =>
+      selectedClient
+        ? projects.filter((prj) => prj.createdById === selectedClient.id)
+        : projects,
+    [projects, selectedClient],
+  );
 
   function closeProjectDetailsModal() {
     setProjectDetailsModalOpen(false);
@@ -40,21 +58,38 @@ export default function FreelancerDashboardContent({
 
   return (
     <>
-      <div className="flex items-center justify-between border-b border-gray-200 px-[5%] py-4">
+      <div className="flex items-center justify-between gap-2 border-b border-gray-200 px-[5%] py-4">
         <h1 className="flex text-xl font-bold capitalize md:text-2xl xl:text-[28px]">
           <ToggleSidebarButton />
-          Freelancer Dashboard
+          <span className="hidden min-[480px]:inline">
+            Freelancer Dashboard
+          </span>
+          <span className="min-[480px]:hidden">Dashboard</span>
         </h1>
+        <Select
+          value={selectedClientId}
+          onChange={(value) => setSelectedClientId(value)}
+          containerClassName="w-40"
+          placeholder="Select a client"
+          options={[
+            { value: "all", label: <span>All</span> },
+            ...clients.map((client) => ({
+              value: client.id,
+              label: <span key={client.id}>{client.fullName}</span>,
+            })),
+          ]}
+        />
       </div>
+
       <div className="mx-auto flex w-[90%] max-w-7xl flex-col gap-6 py-4">
         <PendingProjectsSection
-          projects={projects}
+          projects={filteredProjects}
           updateProjectList={updateProjectList}
           setProjectDetailsModalOpen={setProjectDetailsModalOpen}
           setProjectToView={setProjectToView}
         />
         <ContentCalendar
-          projects={projects as ProjectType[]}
+          projects={filteredProjects as ProjectType[]}
           setProjects={setProjects}
           setProjectToView={setProjectToView}
           setProjectDetailsModalOpen={setProjectDetailsModalOpen}

--- a/components/freelancer-dashboard/PendingProjectsSection.tsx
+++ b/components/freelancer-dashboard/PendingProjectsSection.tsx
@@ -46,12 +46,14 @@ export default function PendingProjectsSection({
           <h3 className="text-lg font-semibold sm:text-xl">
             Projects requiring your attention ({unCompletedProjects.length})
           </h3>
-          <button
-            onClick={() => setShowAll((prev) => !prev)}
-            className="text-accent text-sm font-medium whitespace-nowrap hover:underline focus-visible:underline"
-          >
-            {showAll ? "Show less" : "Show all"}
-          </button>
+          {unCompletedProjects.length > 2 && (
+            <button
+              onClick={() => setShowAll((prev) => !prev)}
+              className="text-accent text-sm font-medium whitespace-nowrap hover:underline focus-visible:underline"
+            >
+              {showAll ? "Show less" : "Show all"}
+            </button>
+          )}
         </div>
         {unCompletedProjects.length > 0 ? (
           <div

--- a/components/newsletter-content/ClientNewsletterPageContent.tsx
+++ b/components/newsletter-content/ClientNewsletterPageContent.tsx
@@ -16,10 +16,12 @@ export default function ClientNewsletterPageContent({
   projects,
   creditsUsedThisMonth,
   totalCredits,
+  userId,
 }: {
   projects: ProjectType[];
   creditsUsedThisMonth: number;
   totalCredits: number;
+  userId?: string;
 }) {
   const [projectList, setProjectList] = useState(projects);
   const [selectedProjectId, setSelectedProjectId] = useState("");
@@ -59,6 +61,7 @@ export default function ClientNewsletterPageContent({
     const { data: newTemplate, error } = await createNewsletterTemplate(
       selectedProjectId,
       projectNewsLetters.at(-1)?.content,
+      userId,
     );
 
     if (newTemplate) {

--- a/components/newsletter-content/ClientNewsletterPageContent.tsx
+++ b/components/newsletter-content/ClientNewsletterPageContent.tsx
@@ -133,7 +133,7 @@ export default function ClientNewsletterPageContent({
         </div>
 
         <div className="mx-auto flex w-[90%] max-w-7xl flex-1 flex-col gap-6 py-4 lg:max-h-[calc(100vh-6rem)] lg:flex-row lg:overflow-y-auto">
-          <div className="flex max-h-[calc(100vh-10rem)] flex-col gap-4 rounded-md border border-gray-200 bg-white p-4 sm:p-6 lg:h-auto lg:flex-1">
+          <div className="flex max-h-[calc(100vh-10rem)] flex-col gap-4 rounded-md border border-gray-200 bg-white p-4 sm:p-6 lg:h-auto lg:max-h-full lg:flex-1">
             <h2 className="font-semibold sm:text-lg md:text-xl xl:text-2xl">
               Select Approved Video
             </h2>

--- a/components/settings/ClientSettingsPage.tsx
+++ b/components/settings/ClientSettingsPage.tsx
@@ -64,36 +64,34 @@ export default function ClientSettingsPage({
 
   function handleChangeSelectedClient(value: string) {
     const foundClient = clients.find((cl) => cl.id === value);
-    if (!foundClient) return;
-    setSelectedClient(foundClient);
+    if (!foundClient) setSelectedClient(null);
+    else setSelectedClient(foundClient);
   }
 
   return (
     <>
-      <div className="flex flex-col gap-4 rounded-md border border-gray-300 bg-white p-4 sm:gap-6 sm:p-6">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold sm:text-xl lg:text-2xl">
-            Select Client
-          </h2>
-          <Select
-            value={selectedClient?.id || ""}
-            onChange={handleChangeSelectedClient}
-            containerClassName="w-40"
-            options={[{ id: "", fullName: "Select a client" }, ...clients].map(
-              (client) => ({
-                value: client.id,
-                label: (
-                  <div
-                    key={client.id}
-                    // className="whitespace-nowrap "
-                  >
-                    {client.fullName}
-                  </div>
-                ),
-              }),
-            )}
-          />
-        </div>
+      <div className="flex items-center justify-between gap-4 rounded-md border border-gray-300 bg-white p-4 sm:gap-6 sm:p-6">
+        <h2 className="text-lg font-semibold sm:text-xl lg:text-2xl">
+          Select Client
+        </h2>
+        <Select
+          value={selectedClient?.id || ""}
+          onChange={handleChangeSelectedClient}
+          containerClassName="w-40"
+          options={[{ id: "", fullName: "Select a client" }, ...clients].map(
+            (client) => ({
+              value: client.id,
+              label: (
+                <div
+                  key={client.id}
+                  // className="whitespace-nowrap "
+                >
+                  {client.fullName}
+                </div>
+              ),
+            }),
+          )}
+        />
       </div>
 
       {selectedClient && (

--- a/components/sidebar/MobileSidebar.tsx
+++ b/components/sidebar/MobileSidebar.tsx
@@ -2,15 +2,11 @@
 
 import { type UserType } from "@/types/user";
 import {
-  EditIcon,
   FileVideoIcon,
   HomeIcon,
   LogOutIcon,
-  MailIcon,
   PanelLeftIcon,
-  SettingsIcon,
   UserCogIcon,
-  UsersIcon,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -19,12 +15,7 @@ import Avatar from "../ui/Avatar";
 import ModalContainer from "../ui/ModalContainer";
 import useSidebarContext from "@/hooks/useSidebarContext";
 import LogoutModal from "../auth/LogoutModal";
-
-const sidebarLinks = [
-  // { title: "Main", url: "/", icon: HomeIcon },
-  { title: "Users", url: "/users", icon: UsersIcon },
-  { title: "User Settings", url: "/settings", icon: SettingsIcon },
-];
+import { sidebarLinks } from "@/lib/data/constants";
 
 export default function MobileSidebar({ user }: { user: UserType }) {
   const { sidebarOpen, setSidebarOpen } = useSidebarContext();
@@ -81,42 +72,11 @@ export default function MobileSidebar({ user }: { user: UserType }) {
                   </li>
                 )}
 
-                {user.role === "CLIENT" && (
-                  <>
-                    <li onClick={closeSidebar}>
-                      <Link
-                        href={"/script-generator"}
-                        className={`flex items-center gap-4 rounded-md p-2 ${
-                          pathname.startsWith("/script-generator")
-                            ? "text-accent-black-200 bg-white font-semibold"
-                            : "font-medium hover:bg-white/10"
-                        }`}
-                      >
-                        <EditIcon className="h-4 w-4" />
-                        Script Generator
-                      </Link>
-                    </li>
-                    <li onClick={closeSidebar}>
-                      <Link
-                        href={"/newsletter-content"}
-                        className={`flex items-center gap-4 rounded-md p-2 ${
-                          pathname === "/newsletter-content"
-                            ? "text-accent-black-200 bg-white font-semibold"
-                            : "font-medium hover:bg-white/10"
-                        }`}
-                      >
-                        <MailIcon className="h-4 w-4" />
-                        Newsletter Content
-                      </Link>
-                    </li>
-                  </>
-                )}
-
                 {sidebarLinks.map((link) => (
                   <li
                     onClick={closeSidebar}
                     key={link.title}
-                    hidden={user.role !== "ADMIN"}
+                    hidden={user.role !== link.validUserRole}
                   >
                     <Link
                       href={link.url}

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -2,15 +2,11 @@
 
 import { type UserType } from "@/types/user";
 import {
-  EditIcon,
   FileVideoIcon,
   HomeIcon,
   LogOutIcon,
-  MailIcon,
   PanelLeftIcon,
-  SettingsIcon,
   UserCogIcon,
-  UsersIcon,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -18,12 +14,7 @@ import React, { useState } from "react";
 import Avatar from "../ui/Avatar";
 import useSidebarContext from "@/hooks/useSidebarContext";
 import LogoutModal from "../auth/LogoutModal";
-
-const sidebarLinks = [
-  // { title: "Main", url: "/", icon: HomeIcon },
-  { title: "Users", url: "/users", icon: UsersIcon },
-  { title: "User Settings", url: "/settings", icon: SettingsIcon },
-];
+import { sidebarLinks } from "@/lib/data/constants";
 
 export default function Sidebar({ user }: { user: UserType }) {
   const pathname = usePathname();
@@ -41,7 +32,7 @@ export default function Sidebar({ user }: { user: UserType }) {
       >
         <div className="flex items-center gap-2 p-4 font-semibold">
           <FileVideoIcon className="h-6 w-6" />
-          <span>Clinic Lead Stack</span>
+          <span className="whitespace-nowrap">Clinic Lead Stack</span>
           <button
             onClick={() => setSidebarOpen((prev) => !prev)}
             className={`ml-auto duration-200 ${!sidebarOpen ? "text-accent-black-200 translate-x-10" : "text-gray-300 hover:text-white"}`}
@@ -69,41 +60,12 @@ export default function Sidebar({ user }: { user: UserType }) {
                   </Link>
                 </li>
               )}
-              {user.role === "CLIENT" && (
-                <>
-                  <li>
-                    <Link
-                      href={"/script-generator"}
-                      className={`flex items-center gap-4 rounded-md p-2 ${
-                        pathname.startsWith("/script-generator")
-                          ? "text-accent-black-200 bg-white font-semibold"
-                          : "font-medium hover:bg-white/10"
-                      }`}
-                    >
-                      <EditIcon className="h-4 w-4" />
-                      Script Generator
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      href={"/newsletter-content"}
-                      className={`flex items-center gap-4 rounded-md p-2 ${
-                        pathname === "/newsletter-content"
-                          ? "text-accent-black-200 bg-white font-semibold"
-                          : "font-medium hover:bg-white/10"
-                      }`}
-                    >
-                      <MailIcon className="h-4 w-4" />
-                      Newsletter Content
-                    </Link>
-                  </li>
-                </>
-              )}
+
               {sidebarLinks.map((link) => (
-                <li key={link.title} hidden={user.role !== "ADMIN"}>
+                <li key={link.title} hidden={user.role !== link.validUserRole}>
                   <Link
                     href={link.url}
-                    className={`flex items-center gap-4 rounded-md p-2 ${
+                    className={`flex items-center gap-4 rounded-md p-2 whitespace-nowrap ${
                       pathname.startsWith(link.url)
                         ? "text-accent-black-200 bg-white font-semibold"
                         : "font-medium hover:bg-white/10"

--- a/lib/data/constants.ts
+++ b/lib/data/constants.ts
@@ -1,0 +1,34 @@
+import {
+  EditIcon,
+  MailIcon,
+  SettingsIcon,
+  UserCogIcon,
+  UsersIcon,
+} from "lucide-react";
+export const sidebarLinks = [
+  { title: "Users", url: "/users", icon: UsersIcon, validUserRole: "ADMIN" },
+  {
+    title: "User Settings",
+    url: "/settings",
+    icon: SettingsIcon,
+    validUserRole: "ADMIN",
+  },
+  {
+    title: "Client Management",
+    url: "/client-management",
+    icon: UserCogIcon,
+    validUserRole: "ADMIN",
+  },
+  {
+    title: "Script Generator",
+    url: "/script-generator",
+    icon: EditIcon,
+    validUserRole: "CLIENT",
+  },
+  {
+    title: "Newsletter Content",
+    url: "/newsletter-content",
+    icon: MailIcon,
+    validUserRole: "CLIENT",
+  },
+];

--- a/services/projectServices.ts
+++ b/services/projectServices.ts
@@ -134,7 +134,8 @@ export async function getFreelancerClientProjects(clientIds: string[]) {
     const projects = (await prisma.project.findMany({
       where: { createdById: { in: clientIds } },
       orderBy: { createdAt: "desc" },
-    })) as ProjectType[];
+      include: { createdBy: true },
+    })) as unknown as ProjectType[];
 
     const signedProjects = await signProjectFiles(projects);
 

--- a/services/userServices.ts
+++ b/services/userServices.ts
@@ -3,15 +3,55 @@ import { UserType } from "@/types/user";
 
 export async function getUserById(id: string) {
   try {
-    const user = await prisma.user.findFirst({
+    const user = (await prisma.user.findFirst({
       where: { id },
-    });
+      include: {
+        assignedClients: {
+          select: {
+            id: true,
+            fullName: true,
+          },
+        },
+        newsletterTemplates: true,
+        videoScripts: true,
+      },
+    })) as unknown as UserType | null;
 
     if (!user) {
       throw new Error("User not found");
     }
 
-    return { data: user as unknown as UserType, error: null };
+    const now = new Date();
+    const newsletterTemplatesCreatedThisMonth =
+      user.newsletterTemplates?.filter((template, index, arr) => {
+        const createdAt = new Date(template.createdAt);
+        const isThisMonth =
+          createdAt.getFullYear() === now.getFullYear() &&
+          createdAt.getMonth() === now.getMonth();
+
+        const isFirstForProject =
+          arr.findIndex(
+            (t) =>
+              t.projectId === template.projectId &&
+              new Date(t.createdAt).getFullYear() === now.getFullYear() &&
+              new Date(t.createdAt).getMonth() === now.getMonth(),
+          ) === index;
+
+        return isThisMonth && isFirstForProject;
+      }) ?? [];
+
+    const sortedVideoTypes = user.videoTypes?.sort((a, b) =>
+      a.localeCompare(b),
+    );
+
+    return {
+      data: {
+        ...user,
+        videoTypes: sortedVideoTypes,
+        creditsUsedThisMonth: newsletterTemplatesCreatedThisMonth.length,
+      },
+      error: null,
+    };
   } catch (err) {
     const error = err as Error;
     return { data: null, error: error.message };

--- a/services/userServices.ts
+++ b/services/userServices.ts
@@ -104,3 +104,29 @@ export async function getClients(): Promise<{
     return { data: [], error: error.message };
   }
 }
+
+export async function getFreelancerClients(userId: string): Promise<{
+  data: UserType[];
+  error: string | null;
+}> {
+  try {
+    let users = await prisma.user.findMany({
+      where: { role: "CLIENT", assignedFreelancers: { some: { id: userId } } },
+      include: {
+        assignedClients: true,
+        assignedFreelancers: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    users = users.map((user) => ({
+      ...user,
+      videoTypes: user.videoTypes.sort((a, b) => a.localeCompare(b)),
+    }));
+
+    return { data: users as unknown as UserType[], error: null };
+  } catch (err) {
+    const error = err as Error;
+    return { data: [], error: error.message };
+  }
+}


### PR DESCRIPTION
- Added client-specific dropdown to Content Calendar for better project separation when managing multiple clients.
- Enabled Admins to view both Clients' and Freelancers' accounts, with initial support for Newsletter repurposing; YouTube Shorts support to follow.
- Improved mobile drag-and-drop functionality for scheduling projects; current UX still not ideal but more stable than vertical calendar.
- Implemented upload flow for Freelancers to submit deliverables for Client approval directly via their dashboard.